### PR TITLE
Fix/remove sage method from docs

### DIFF
--- a/cryptographic_estimators/base_algorithm.py
+++ b/cryptographic_estimators/base_algorithm.py
@@ -21,11 +21,11 @@ from .helper import ComplexityType
 from .base_problem import BaseProblem
 import functools
 from math import inf, log2
-from .base_constants import *
+from .base_constants import BASE_BIT_COMPLEXITIES, BASE_COMPLEXITY_TYPE, BASE_ESTIMATE, BASE_MEMORY_ACCESS, BASE_TILDEO
 
 
 class BaseAlgorithm:
-    def __init__(self, problem, **kwargs):
+    def __init__(self, problem: BaseProblem, **kwargs):
         """
         Base class for algorithms complexity estimator
 
@@ -426,15 +426,14 @@ class BaseAlgorithm:
         else:
             params = self.__set_dict(**kwargs)
 
-
-
         if self._complexity_type == ComplexityType.ESTIMATE.value:
             self._time_complexity = self._compute_time_complexity(params)
             if self.bit_complexities:
                 self._time_complexity = self.problem.to_bitcomplexity_time(
                     self._time_complexity)
 
-            self._time_complexity += self.memory_access_cost(self.memory_complexity())
+            self._time_complexity += self.memory_access_cost(
+                self.memory_complexity())
 
         else:
             self._time_complexity = self._compute_tilde_o_time_complexity(

--- a/cryptographic_estimators/base_estimator.py
+++ b/cryptographic_estimators/base_estimator.py
@@ -17,11 +17,10 @@
 
 
 from math import isinf
-from sage.all import *
 from typing import Union, Callable
 from .helper import ComplexityType
-from .base_constants import *
-from .base_algorithm import *
+from .base_constants import BASE_TILDEO_ESTIMATE, BASE_ADDITIONALO, BASE_BIT_COMPLEXITIES, BASE_ESTIMATEO, BASE_EXCLUDED_ALGORITHMS, BASE_MEMORY, BASE_PARAMETERS, BASE_QUANTUMO, BASE_TIME
+from .base_algorithm import BaseAlgorithm
 from .estimation_renderer import EstimationRenderer
 
 
@@ -227,7 +226,8 @@ class BaseEstimator(object):
 
         est[name][BASE_ESTIMATEO][BASE_PARAMETERS] = algorithm.get_optimal_parameters_dict()
 
-        est[name][BASE_ADDITIONALO] = algorithm._get_verbose_information() if not isinf(algorithm.time_complexity()) else {}
+        est[name][BASE_ADDITIONALO] = algorithm._get_verbose_information(
+        ) if not isinf(algorithm.time_complexity()) else {}
 
     def estimate(self, **kwargs):
         """

--- a/cryptographic_estimators/estimation_renderer.py
+++ b/cryptographic_estimators/estimation_renderer.py
@@ -20,7 +20,7 @@ from .base_constants import BASE_ALGORITHM, BASE_PARAMETERS, BASE_TIME, BASE_MEM
 from .helper import concat_all_tables, round_or_truncate
 from copy import deepcopy
 from prettytable import PrettyTable
-from sage.rings.all import RR
+from sage.all import RR
 
 
 class EstimationRenderer():


### PR DESCRIPTION
Remove `imports` with `*` and prevent the documentation to show unnecessary methods